### PR TITLE
Read-back returned status outputs

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -16,7 +16,14 @@ pub enum MediaType {
 
 #[derive(Clone)]
 pub enum ZplCommand {
-    Raw(String),
+    Raw {
+        text: String,
+        /// How many 'lines' / fields of text to read back after the sequence, to purge what the
+        /// print would send from the buffer. If we want to raw-ify commands that send non-text
+        /// delimited fields then we should look into having a proper sequence encoded in this
+        /// field.
+        response_lines: u32,
+    },
     Magic,
     PersistConfig,
     SetDarkness(usize),
@@ -45,14 +52,29 @@ pub enum ZplCommand {
         replicates: u32,
         cut_only: bool,
     },
+    HostIndication,
+    HostRamStatus,
+    HostStatusReturn,
     Start,
     End,
+}
+
+impl ZplCommand {
+    /// How many lines of text
+    pub fn how_many_lines_of_text(&self) -> u32 {
+        match self {
+            ZplCommand::HostIndication => 1,
+            ZplCommand::HostRamStatus => 1,
+            ZplCommand::HostStatusReturn => 3,
+            _ => 0,
+        }
+    }
 }
 
 impl From<ZplCommand> for String {
     fn from(value: ZplCommand) -> Self {
         match value {
-            ZplCommand::Raw(s) => s,
+            ZplCommand::Raw { text, .. } => text,
             ZplCommand::Magic => vec!["CT~~CD,~CC^~CT~", "^XA~TA000~JSN^LT0^MNW"].join("\n"),
             // Removed:
             // -
@@ -105,13 +127,20 @@ impl From<ZplCommand> for String {
             }
             ZplCommand::Start => "^XA".to_string(),
             ZplCommand::End => "^XZ".to_string(),
+            ZplCommand::HostIndication => "~HI".to_string(),
+            ZplCommand::HostRamStatus => "~HM".to_string(),
+            ZplCommand::HostStatusReturn => "~HS".to_string(),
         }
     }
 }
 
 #[test]
 fn test_raw() {
-    let c = ZplCommand::Raw("Abc".to_string());
+    let c = ZplCommand::Raw {
+        text: "Abc".to_string(),
+        response_lines: 0,
+    };
+
     assert_eq!(String::from(c), "Abc");
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -39,5 +39,8 @@ pub fn render_image(img: &image::DynamicImage) -> ZplCommand {
 
     let output = format!("^GFA,{byte_count},{total_field_count},{bytes_per_row},{data}^FS");
 
-    ZplCommand::Raw(output)
+    ZplCommand::Raw {
+        text: output,
+        response_lines: 0,
+    }
 }

--- a/src/label.rs
+++ b/src/label.rs
@@ -5,6 +5,15 @@ pub struct Label {
     pub commands: Vec<ZplCommand>,
 }
 
+impl Label {
+    pub fn how_many_lines_of_text(&self) -> u32 {
+        self.commands
+            .iter()
+            .map(ZplCommand::how_many_lines_of_text)
+            .sum()
+    }
+}
+
 impl core::fmt::Display for Label {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for inner in &self.commands {

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,0 +1,54 @@
+use std::io;
+use tokio::io::AsyncReadExt;
+
+pub struct DiagnosticString {
+    #[allow(dead_code)]
+    pub start: Vec<u8>,
+    pub string: Vec<u8>,
+}
+
+pub async fn line_with(
+    buf: &mut Vec<u8>,
+    rx: &mut (impl AsyncReadExt + core::marker::Unpin),
+) -> Result<DiagnosticString, io::Error> {
+    let post_etx = 'brk: {
+        if let Some(pos) = buf.iter().position(|c| *c == b'\x03') {
+            break 'brk pos + 1;
+        }
+
+        let mut read_buf = [0; 128];
+
+        loop {
+            let n = rx.read(&mut read_buf).await?;
+
+            if n == 0 {
+                return Err(io::ErrorKind::BrokenPipe)?;
+            }
+
+            let post_fin = read_buf[..n]
+                .iter()
+                .position(|c| *c == b'\x03')
+                .map(|x| x + 1 + buf.len());
+
+            buf.extend_from_slice(&read_buf[..n]);
+
+            if let Some(fin) = post_fin {
+                break 'brk fin;
+            }
+        }
+    };
+
+    let tail = buf.split_off(post_etx);
+
+    let mut line = core::mem::replace(buf, tail);
+    let _ = line.pop();
+
+    // if there's anything before, discard it.
+    let start = line.iter().position(|c| *c == b'\x02').map_or(0, |n| n + 1);
+    let string = line.split_off(start);
+
+    return Ok(DiagnosticString {
+        start: line,
+        string,
+    });
+}


### PR DESCRIPTION
So that I remember, since it'll require a bit of merging. Makes it possible to model commands that expect a line of text sent back, delimited by `stx`/`etx` pairs. For completeness sake the portion of the connection outside those delimiters is also set in the `start` field but it should be ignored.