### PR TITLE
Integration testing outcomes

### DIFF
--- a/server/server.json
+++ b/server/server.json
@@ -15,7 +15,10 @@
 		"gx430t": {
 			"label": "51mm",
 			"addr": "192.168.179.111:9100",
-			"display_name": "Porkhy"
+			"display_name": "Porkhy",
+			"calibration": {
+				"home_x": 2.0
+			}
 		},
 		"gx430t-virtualized": {
 			"label": "51mm",

--- a/server/src/configuration.rs
+++ b/server/src/configuration.rs
@@ -36,6 +36,9 @@ pub struct LabelPrinter {
     pub display_name: Option<String>,
 
     #[serde(default)]
+    pub calibration: Option<LabelCalibration>,
+
+    #[serde(default)]
     /// If this is not a physical printer, how do we handle it?
     pub virtualization: LabelVirtualization,
 }
@@ -61,12 +64,24 @@ pub enum LabelVirtualization {
 
 #[derive(Deserialize, Serialize)]
 pub struct LabelDimensions {
+    /// Width of the label in mm.
     pub width: f32,
+    /// Height of the label in mm.
     pub height: f32,
+    /// Space to reserve on the left of the label, as by printed direction.
     pub margin_left: f32,
+    /// Space to reserve on the right of the label, as by printed direction.
     pub margin_right: f32,
+    /// Space to reserve on top of the label, as by printed direction.
     pub margin_top: f32,
+    /// Space to reserve at the bottom of the label, as by printed direction.
     pub margin_bottom: f32,
+}
+
+#[derive(Default, Deserialize, Serialize)]
+pub struct LabelCalibration {
+    /// Offset of the label towards the right (positive width) in mm.
+    pub home_x: f32,
 }
 
 impl Configuration {

--- a/server/src/index.html
+++ b/server/src/index.html
@@ -155,7 +155,7 @@
         }
       }
 
-      document.getElementById('zpl-api-print').onclick = function() {
+      document.getElementById('zpl-api-print').onclick = function(ev) {
         const [file] = document.getElementById('zpl-api-file').files;
 
         if (file == undefined) {
@@ -194,6 +194,9 @@
 
           document.getElementById('zpl-status').innerText = await response.text();
         })();
+
+        ev.preventDefault();
+        return false;
       }
 
       window.addEventListener('load', async () => {

--- a/server/src/physical_printer.rs
+++ b/server/src/physical_printer.rs
@@ -1,4 +1,5 @@
 use crate::{configuration, job, ShutdownToken};
+use zpl::label::{PrintCalibration, PrintOptions, Unit};
 
 use log::{debug, error, info, warn};
 
@@ -338,7 +339,20 @@ async fn print_label(
         )
     });
 
-    let seq = label.print(1).await?;
+    let options = {
+        let mut options = PrintOptions::default();
+
+        options.copies = 1;
+        if let Some(cfg) = &con.target.config.calibration {
+            options.calibration = Some(PrintCalibration {
+                home_x: Unit::Millimetres(cfg.home_x),
+            });
+        }
+
+        options
+    };
+
+    let seq = label.print(&options).await?;
     // tokio::fs::write("/tmp/zpl-debug", seq.to_string()).await?;
     con.printer.send(seq).await?;
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -99,11 +99,11 @@ pub enum ZplCommand {
     SetPrintWidth(u32),
     SetLabelLength(u32),
     SetPostPrintAction(PostPrintAction),
-    SetHorizontalShift(usize),
+    SetHorizontalShift(i32),
     /// Move the entire label content vertically up or down, relative
     /// to the upper edge of the label. Accepts an offset of up to 120
     /// dots.
-    SetVerticalShift(isize),
+    SetVerticalShift(i32),
     SetTearOffPosition(isize),
     /// Mirror the label vertically
     SetMirrored(bool),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,13 @@ pub async fn make_label(
         bail!("No image/vector source selected");
     };
 
-    let commands = label.print(copies.get()).await?;
+    let commands = label
+        .print(&{
+            let mut options = label::PrintOptions::default();
+            options.copies = copies.get();
+            options
+        })
+        .await?;
 
     Ok(commands)
 }


### PR DESCRIPTION
- If in a wrong network, don't block the connection attempt forever. Error and retry is forward progress, assuming that the environment may change into a different default netdev / route.
- For non-Firefox browsers the button in the `<form>` reloads by doing its own actual request. Stop that from happening in favor of our custom request.
- Introduce calibration parameters to labels. Defaults to `0` and thus no pixel offset but could be configured. This is mostly for testing purposes right now since re-writing the nix deployment is not a very useful way of applying the calibration when it needs to be performed after changing the label.. Something that was planned to happen without causing a full redeploy.